### PR TITLE
Ability to apply DataTables on tables from other plugins

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,52 +22,48 @@ var $wrap_tables = jQuery(WRAP_TABLES_SELECTOR);
 
 
 function init_datatables($target_table, dt_config) {
-
-  // Exclude all tables with {row,col}span
-  if (! $target_table.find('[rowspan], [colspan]').length) {
-    
-    var headerRows = dt_config.headerRows;
-    if (headerRows) {
-      // Retrieve any already existing thead.
-      var $thead = jQuery('thead', $target_table),
-          $tbody = jQuery('tbody', $target_table),
-          missingThead = $thead.size() === 0;
-      headerRows -= $thead.children().size();
-      if (missingThead) {
-        $thead = jQuery('<thead>');
-      }
-      while(headerRows > 0) {
-        headerRows--;
-        $thead.append($tbody.children().first());
-      }
-      if (missingThead) {
-        $target_table.prepend($thead);
-      }
+  // Build the thead if requested, before checking for thead existence and absence of (col|row)span in tbody.
+  var headerRows = dt_config.headerRows;
+  if (headerRows) {
+    // Retrieve any already existing thead.
+    var $thead = jQuery('thead', $target_table),
+        $tbody = jQuery('tbody', $target_table),
+        missingThead = $thead.size() === 0;
+    headerRows -= $thead.children().size();
+    if (missingThead) {
+      $thead = jQuery('<thead>');
     }
-    
-    // Make sure the table has a thead with at least 1 row.
-    if (jQuery('thead > tr', $target_table).size()) {
-      // Launch DataTable.
-      $target_table.DataTable(dt_config);
+    while(headerRows > 0) {
+      headerRows--;
+      $thead.append($tbody.children().first());
+    }
+    if (missingThead) {
+      $target_table.prepend($thead);
     }
   }
+  
+  // Make sure the table has a thead with at least 1 row and that no (col|row)span is used in tbody, because DataTables does not support this.
+  if (jQuery('thead > tr', $target_table).size() && !jQuery('tbody', $target_table).find('[rowspan], [colspan]').length) {
+    // Launch DataTable.
+    $target_table.DataTable(dt_config);
+    
+    // Config is already available in dt_config parameter.
+    // Moved creation of fixed header inside the conditional block, so that it happens only if the table is converted into a DataTable.
+    if (dt_config.fixedHeaderEnable) {
 
-  // Config is already available in dt_config parameter.
-  if (dt_config.fixedHeaderEnable) {
+      var options = {};
 
-    var options = {};
+      jQuery.each(dt_config, function(key, value) {
+        switch (key) {
+          case 'fixedHeaderOffsetTop':
+            options['offsetTop'] = value;
+        }
+      });
 
-    jQuery.each(dt_config, function(key, value) {
-      switch (key) {
-        case 'fixedHeaderOffsetTop':
-          options['offsetTop'] = value;
-      }
-    });
+      new jQuery.fn.dataTable.FixedHeader($target_table, options);
 
-    new jQuery.fn.dataTable.FixedHeader($target_table, options);
-
+    }
   }
-
 }
 
 

--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ function init_datatables($target_table, dt_config) {
     }
     
     // Make sure the table has a thead with at least 1 row.
-    if (jQuery('thead', $target_table).children().size()) {
+    if (jQuery('thead > tr', $target_table).size()) {
       // Launch DataTable.
       $target_table.DataTable(dt_config);
     }

--- a/syntax.php
+++ b/syntax.php
@@ -13,16 +13,17 @@ if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 class syntax_plugin_datatables extends DokuWiki_Syntax_Plugin {
 
     function getType(){ return 'container';}
-    function getAllowedTypes() { return array('container'); }
+    // Added susbstition allowed type, so that Doku renders tables from other plugins, then DataTable can be applied on them.
+    function getAllowedTypes() { return array('container', 'substition'); }
     function getPType(){ return 'block';}
     function getSort(){ return 195; }
 
     function connectTo($mode) {
-      $this->Lexer->addEntryPattern('<(?:DATATABLES|datatables|datatable).*?>(?=.*?</(?:DATATABLES|datatables|datatable)>)', $mode, 'plugin_datatables');
+      $this->Lexer->addEntryPattern('<(?:DATATABLES?|datatables?)\b.*?>(?=.*?</(?:DATATABLES?|datatables?)>)', $mode, 'plugin_datatables');
     }
 
     public function postConnect() {
-      $this->Lexer->addExitPattern('</(?:DATATABLES|datatables|datatable)>', 'plugin_datatables');
+      $this->Lexer->addExitPattern('</(?:DATATABLES?|datatables?)>', 'plugin_datatables');
     }
 
     function handle($match, $state, $pos, Doku_Handler $handler) {


### PR DESCRIPTION
Hi,

This PR proposes to enable using DataTables on tables rendered by other plugin (e.g. csv and structured data).

There are currently 2 issues that prevent doing so:
- Substitution plugins are not rendered within a datatable container. Therefore we cannot apply DataTables on a table built by another plugin.
- Even after the table is created, the 3rd party plugin may not format the table correctly (missing thead). Therefore we need either to correct each plugin we want to use, or we need a post-factory to create the thead.

What this PR does:
- Adds `substition` allowed type. This allows substitution plugins to render their own tables.
- Adds an extra option `header-rows="X"` in datatable opening tag, which specifies the number of top rows to be included in the table thead. Also checked on DataTables.net that this option name does not exist yet.
- Looks for all tables in `.dt-wrapper` container (even without thead).
- Creates or appends the thead according to `header-rows` attribute.
- Creates the DataTable __only__ if a proper thead exists after this step.

It also slightly improves the syntax (entry and exit patterns), and the javascript for retrieval of fixedHeaderOffsetTop value.