### PR TITLE
Format data- attributes with ' single quotes

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -54,7 +54,7 @@ class syntax_plugin_datatables extends DokuWiki_Syntax_Plugin {
             $xml = simplexml_load_string(str_replace('>', '/>', $match));
 
             foreach ($xml->attributes() as $key => $value) {
-              $html5_data[] = sprintf('data-%s="%s"', $key, (string) $value);
+              $html5_data[] = sprintf("data-%s='%s'", $key, str_replace("'", "&apos;", (string) $value));
             }
 
             $renderer->doc .= sprintf('<div class="dt-wrapper" %s>', implode(' ', $html5_data));


### PR DESCRIPTION
Hi,

Following issue #7, this modification makes it possible to use double quotes `"` in value of `data-` attributes, so that they can be passed to DataTables JavaScript through jQuery (see also https://datatables.net/manual/options).

It simply reverses the use of single quotes `'` (which are now used to delimit the value of the attribute) and double quotes `"` (which are now used to delimit the string first argument of `sprintf` function call).

Furthermore, it also escapes (html entity) any extra single quote `'` that may be used in the attribute value. With the previous code, any quote is passed as-is and breaks the xml syntax.